### PR TITLE
Fix undefined method `[]' for nil:NilClass

### DIFF
--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -60,7 +60,7 @@ module Capistrano::BundleRsync
     # NOTE: :password is not supported.
     def self.build_ssh_command(host)
       user_opt, key_opt, port_opt = "", "", ""
-      ssh_options = fetch(:bundle_rsync_ssh_options) || fetch(:ssh_options)
+      ssh_options = fetch(:bundle_rsync_ssh_options) || fetch(:ssh_options) || {}
       if user = host.user || ssh_options[:user]
         user_opt = " -l #{user}"
       end


### PR DESCRIPTION
If `bundle_rsync_ssh_options` and `ssh_options are not configured, cap deploy fails.

```
$ bundle exec cap production deploy
..snip..
cap aborted!
NoMethodError: undefined method `[]' for nil:NilClass
/path/to/vendor/bundle/ruby/2.2.0/gems/capistrano-bundle_rsync-0.4.0/lib/capistrano/bundle_rsync/config.rb:64:in `build_ssh_command'
/path/to/vendor/bundle/ruby/2.2.0/gems/capistrano-bundle_rsync-0.4.0/lib/capistrano/bundle_rsync/git.rb:41:in `block in rsync_release'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:438:in `call'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:438:in `call_with_index'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:250:in `block (3 levels) in work_in_threads'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:447:in `with_instrumentation'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:249:in `block (2 levels) in work_in_threads'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:243:in `loop'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:243:in `block in work_in_threads'
/path/to/vendor/bundle/ruby/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:138:in `block (2 levels) in in_threads'
Tasks: TOP => bundle_rsync:rsync_release
The deploy has failed with an error: undefined method `[]' for nil:NilClass
** Invoke deploy:failed (first_time)
** Execute deploy:failed
```