### PR TITLE
Force :bundle_rsync_max_parallels to be integer

### DIFF
--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -81,7 +81,7 @@ module Capistrano::BundleRsync
     # Fetch the :bundle_rsync_max_parallels,
     # where the default is the number of hosts
     def self.max_parallels(hosts)
-      fetch(:bundle_rsync_max_parallels) || hosts.size
+      fetch(:bundle_rsync_max_parallels, hosts.size).to_i
     end
 
     def self.rsync_options


### PR DESCRIPTION
The example `set :bundle_rsync_max_parallels, ENV['PARA']` written in README does not work. When I run `$ PARA=1 cap production deploy` , it raises ArgumentError as follow: `ENV['PARA']` returns "1" as String.

```
** Invoke bundle_rsync:rsync_release (first_time)
** Execute bundle_rsync:rsync_release
cap aborted!
ArgumentError: comparison of String with 1 failed
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:183:in `each'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:183:in `min'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:183:in `map'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/parallel-1.4.1/lib/parallel.rb:154:in `each'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/capistrano-bundle_rsync-2b82efa6b54b/lib/capistrano/bundle_rsync/git.rb:41:in `rsync_release'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/capistrano-bundle_rsync-2b82efa6b54b/lib/capistrano/tasks/bundle_rsync.rake:82:in `block (3 levels) in <top (required)>'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/sshkit-1.6.1/lib/sshkit/backends/local.rb:14:in `instance_exec'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/sshkit-1.6.1/lib/sshkit/backends/local.rb:14:in `run'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/gems/capistrano-3.3.5/lib/capistrano/dsl.rb:59:in `run_locally'
/usr/local/ruby/versions/2.2.0/lib/ruby/gems/2.2.0/bundler/gems/capistrano-bundle_rsync-2b82efa6b54b/lib/capistrano/tasks/bundle_rsync.rake:81:in `block (2 levels) in <top (required)>'
``` 
