### PR TITLE
Filter servers when running rsync on local

### DIFF
--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -1,4 +1,5 @@
 require 'capistrano/bundle_rsync/base'
+require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
@@ -28,6 +29,7 @@ BUNDLE_BIN: #{release_path.join('bin')}
     bundle_config_path = "#{config.local_base_path}/bundle_config"
     File.open(bundle_config_path, "w") {|file| file.print(lines) }
 
+    hosts = ::Capistrano::Configuration.env.filter(hosts)
     rsync_options = config.rsync_options
     Parallel.each(hosts, in_threads: config.max_parallels(hosts)) do |host|
       ssh = config.build_ssh_command(host)

--- a/lib/capistrano/bundle_rsync/git.rb
+++ b/lib/capistrano/bundle_rsync/git.rb
@@ -1,4 +1,5 @@
 require 'capistrano/bundle_rsync/scm'
+require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::Git < Capistrano::BundleRsync::SCM
   def check
@@ -35,7 +36,7 @@ class Capistrano::BundleRsync::Git < Capistrano::BundleRsync::SCM
   end
 
   def rsync_release
-    hosts = release_roles(:all)
+    hosts = ::Capistrano::Configuration.env.filter(release_roles(:all))
     rsync_options = config.rsync_options
     Parallel.each(hosts, in_threads: config.max_parallels(hosts)) do |host|
       ssh = config.build_ssh_command(host)

--- a/lib/capistrano/bundle_rsync/local_git.rb
+++ b/lib/capistrano/bundle_rsync/local_git.rb
@@ -1,4 +1,5 @@
 require 'capistrano/bundle_rsync/scm'
+require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::LocalGit < Capistrano::BundleRsync::SCM
   def check
@@ -17,7 +18,7 @@ class Capistrano::BundleRsync::LocalGit < Capistrano::BundleRsync::SCM
   end
 
   def rsync_release
-    hosts = release_roles(:all)
+    hosts = ::Capistrano::Configuration.env.filter(release_roles(:all))
     rsync_options = config.rsync_options
     Parallel.each(hosts, in_threads: config.max_parallels(hosts)) do |host|
       ssh = config.build_ssh_command(host)

--- a/lib/capistrano/bundle_rsync/scm.rb
+++ b/lib/capistrano/bundle_rsync/scm.rb
@@ -1,4 +1,5 @@
 require 'capistrano/bundle_rsync/base'
+require 'capistrano/configuration/filter'
 
 # Base class for SCM strategy providers.
 #
@@ -88,7 +89,7 @@ class Capistrano::BundleRsync::SCM < Capistrano::BundleRsync::Base
   #
   # @return void
   def rsync_shared
-    hosts = release_roles(:all)
+    hosts = ::Capistrano::Configuration.env.filter(release_roles(:all))
     rsync_options = config.rsync_options
 
     if config_files = config.config_files


### PR DESCRIPTION
This fixes `--hosts` and `--roles` options to work.

As you know, servers are filtered when execute is called in `on` block. But rsync is called in `run_locally` block not in `on`, so they are not filtered.