### PR TITLE
Not remove bundle config file

### DIFF
--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -4,8 +4,10 @@ require 'capistrano/configuration/filter'
 class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
     Bundler.with_clean_env do
-      execute :bundle, "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without development test"
-      execute :rm, "#{config.local_release_path}/.bundle/config"
+      with bundle_app_config: config.local_base_path do
+        execute :bundle, "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without development test"
+        execute :rm, "#{config.local_base_path}/config"
+      end
     end
   end
 


### PR DESCRIPTION
If `.bundle/config` already exists, I don't want to remove it.
So bundle config file location specified.

`BUNDLE_APP_CONFIG` used bundle ~> 1.0.0.rc.4