### PR TITLE
Support bundle install with --standalone option

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--require spec_helper

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ bundle_rsync_rsync_options | `-az --delete` | Configuration of rsync options.
 bundle_rsync_config_files | `nil` | Additional files to rsync. Specified files are copied into `config` directory.
 bundle_rsync_shared_dirs | `nil` | Additional directories to rsync. Specified directories are copied into `shared` directory.
 bundle_rsync_skip_bundle | false | (Secret option) Do not `bundle` and rsync bundle.
+bundle_rsync_bundle_install_standalone | `nil` | bundle install with --standalone option. Set one of `true`, `false`, an `Array` of groups, or a white space separated `String`.
 
 ## Task Orders
 

--- a/capistrano-bundle_rsync.gemspec
+++ b/capistrano-bundle_rsync.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'parallel'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec", "~> 3"
 end

--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -5,7 +5,11 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
     Bundler.with_clean_env do
       with bundle_app_config: config.local_base_path do
-        execute :bundle, "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without development test"
+        opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without development test"
+        if standalone = config.bundle_install_standalone_option
+          opts += " #{standalone}"
+        end
+        execute :bundle, opts
         execute :rm, "#{config.local_base_path}/config"
       end
     end

--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -92,5 +92,22 @@ module Capistrano::BundleRsync
     def self.skip_bundle
       fetch(:bundle_rsync_skip_bundle)
     end
+
+    def self.bundle_install_standalone
+      fetch(:bundle_rsync_bundle_install_standalone)
+    end
+
+    def self.bundle_install_standalone_option
+      case value = self.bundle_install_standalone
+      when true
+        "--standalone"
+      when Array
+        "--standalone #{value.join(' ')}"
+      when String
+        "--standalone #{value}"
+      else
+        nil
+      end
+    end
   end
 end

--- a/spec/capistrano/bundle_rsync/config_spec.rb
+++ b/spec/capistrano/bundle_rsync/config_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+
+describe Capistrano::BundleRsync::Config do
+  describe '.bundle_install_standalone_option' do
+    before {
+      allow(described_class).to receive(:fetch).with(:bundle_rsync_bundle_install_standalone).and_return(value)
+    }
+    subject { described_class.bundle_install_standalone_option }
+    context "`set :bundle_rsync_bundle_install_standalone, nil` or the case that it does not be configured" do
+      let(:value) { nil }
+      it { should eq nil }
+    end
+    context "`set :bundle_rsync_bundle_install_standalone, true`" do
+      let(:value) { true }
+      it { should eq "--standalone" }
+    end
+    context "`set :bundle_rsync_bundle_install_standalone, false`" do
+      let(:value) { false }
+      it { should eq nil }
+    end
+    context "`set :bundle_rsync_bundle_install_standalone, ['foo', 'bar']" do
+      let(:value) { %w(foo bar) }
+      it { should eq "--standalone foo bar" }
+    end
+    context "`set :bundle_rsync_bundle_install_standalone, [:foo, :bar]" do
+      let(:value) { [:foo, :bar] }
+      it { should eq "--standalone foo bar" }
+    end
+    context "`set :bundle_rsync_bundle_install_standalone, 'foo bar'" do
+      let(:value) { 'foo bar' }
+      it { should eq "--standalone foo bar" }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,4 @@
+require 'capistrano/all'
+
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'capistrano/bundle_rsync'


### PR DESCRIPTION
This features enable users to install gems with --standalone option.

In my case, I have monitoring scripts and related gems managed in Gemfile. In production, running with `bundle exec` prefix or binstubbing is a little slow and uses cpu. So, Instead, loading bundler/setup.rb  which is created by --standalone is faster. 

ref. http://myronmars.to/n/dev-blog/2012/03/faster-test-boot-times-with-bundler-standalone is well described.