### PR TITLE
Support repo_tree with local_git

### DIFF
--- a/lib/capistrano/bundle_rsync/local_git.rb
+++ b/lib/capistrano/bundle_rsync/local_git.rb
@@ -22,7 +22,11 @@ class Capistrano::BundleRsync::LocalGit < Capistrano::BundleRsync::SCM
     rsync_options = config.rsync_options
     Parallel.each(hosts, in_threads: config.max_parallels(hosts)) do |host|
       ssh = config.build_ssh_command(host)
-      execute :rsync, "#{rsync_options} --rsh='#{ssh}' #{repo_url}/ #{host}:#{release_path}/"
+      if tree = fetch(:repo_tree)
+        execute :rsync, "#{rsync_options} --rsh='#{ssh}' #{repo_url}/#{tree}/ #{host}:#{release_path}/"
+      else
+        execute :rsync, "#{rsync_options} --rsh='#{ssh}' #{repo_url}/ #{host}:#{release_path}/"
+      end
     end
   end
 


### PR DESCRIPTION
Hi sonots-san,

Thanks for your great gem. This is super "便利".

I'd like to set `repo_tree` with `local_git` as same as `git`. So I've made a little change to `local_git.rb`.

Please check it.
