### PR TITLE
Suppress log by filtering remote refs

### DIFF
--- a/lib/capistrano/bundle_rsync/git.rb
+++ b/lib/capistrano/bundle_rsync/git.rb
@@ -3,7 +3,7 @@ require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::Git < Capistrano::BundleRsync::SCM
   def check
-    exit 1 unless execute("git ls-remote #{repo_url}")
+    exit 1 unless execute("git ls-remote #{repo_url} HEAD")
     execute("mkdir -p #{config.local_base_path}")
   end
 

--- a/lib/capistrano/bundle_rsync/local_git.rb
+++ b/lib/capistrano/bundle_rsync/local_git.rb
@@ -4,7 +4,7 @@ require 'capistrano/configuration/filter'
 class Capistrano::BundleRsync::LocalGit < Capistrano::BundleRsync::SCM
   def check
     raise ArgumentError.new('`repo_url` must be local path to use `local_git` scm') unless local_path?(repo_url)
-    exit 1 unless execute("git ls-remote #{repo_url}")
+    exit 1 unless execute("git ls-remote #{repo_url} HEAD")
     execute("mkdir -p #{config.local_base_path}")
   end
 


### PR DESCRIPTION
@sonots 

This patch can suppress long logs generated by `git ls-remote`, especially for repositories with many tags and branches.

Because the primary objective of `git ls-remote` used in capistrano-bundle_rsync is to check the access rights to `remote_url`, we can omit a number of remote refs by specifying HEAD as `<refs>` at the end of the command.

Although the default exit code of `git ls-remote` is always 0 regardless of matched refs, I think specifying `HEAD` as `<refs>` is fairly simple option for Git users.

Ref. https://git-scm.com/docs/git-ls-remote.html