### PR TITLE
Modify command "git remote update" to use "--prune" option

### DIFF
--- a/lib/capistrano/bundle_rsync/git.rb
+++ b/lib/capistrano/bundle_rsync/git.rb
@@ -17,7 +17,7 @@ class Capistrano::BundleRsync::Git < Capistrano::BundleRsync::SCM
 
   def update
     within config.local_mirror_path do
-      execute :git, :remote, :update
+      execute :git, :remote, :update, '--prune'
     end
   end
 


### PR DESCRIPTION
Hello,

I want add this small improvement.
With this change, one can clean up stale remote-tracking branches in local mirror repository that are already removed from the remote repository.

cf) https://git-scm.com/docs/git-remote#_commands