### PR TITLE
local_git scm deploy failed

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ bundle_rsync_scm | `git` | SCM Strategy inside `bundle_rsync`. `git` uses git. `
 bundle_rsync_local_base_path   | `$(pwd)/.local_repo` | The base directory to clone repository
 bundle_rsync_local_mirror_path | `#{base_path}/mirror"` | Path where to mirror your repository
 bundle_rsync_local_releases_path | `"#{base_path}/releases"` | The releases base directory to checkout your repository
-bundle_rsync_local_release_path | `"#{releases_path}/#{datetime}"` | The full path directory to checkout your repository. If you specify this, `keep_releases` for local releases path is disabled because `datetime` directories are no longer created.
+bundle_rsync_local_release_path | `"#{releases_path}/#{datetime}"` | The full path directory to checkout your repository. If you specify this, `keep_releases` for local releases path is disabled because `datetime` directories are no longer created. This parameter is set as `repo_url` in the case of `local_git` as default.
 bundle_rsync_local_bundle_path | `"#{base_path}/bundle"` | Path where to bundle install gems.
 bundle_rsync_ssh_options | `ssh_options` | Configuration of ssh for rsync. Default uses the value of `ssh_options`
 bundle_rsync_keep_releases | `keep_releases` | The number of releases to keep on .local_repo

--- a/lib/capistrano/tasks/bundle_rsync.rake
+++ b/lib/capistrano/tasks/bundle_rsync.rake
@@ -17,6 +17,7 @@ namespace :bundle_rsync do
     @bundle_rsync_scm ||=
       if fetch(:bundle_rsync_scm).to_s == 'local_git'
         require 'capistrano/bundle_rsync/local_git'
+        set :bundle_rsync_local_release_path, repo_url
         Capistrano::BundleRsync::LocalGit.new(self)
       else
         require 'capistrano/bundle_rsync/git'


### PR DESCRIPTION
Run example code, failing below error.

```
$ bundle exec cap local_git deploy
[Deprecation Notice] `set :scm, :bundle_rsync` is deprecated.
To ensure this custom SCM will work with future versions of Capistrano,
please upgrade it to a version that uses the new SCM plugin mechanism
documented here:

http://capistranorb.com/documentation/advanced-features/custom-scm

00:00 bundle_rsync:check
      01 git ls-remote /home/hkobayash/capistrano-bundle_rsync/example/try_rails4 HEAD
      01 78656aba46a28872d1f5f0ae6196f7e5496e1817       HEAD
      01 78656aba46a28872d1f5f0ae6196f7e5496e1817       refs/remotes/origin/HEAD
    ✔ 01 hkobayash@localhost 0.028s
      02 mkdir -p /home/hkobayash/capistrano-bundle_rsync/example/.local_repo
    ✔ 02 hkobayash@localhost 0.001s
00:00 deploy:check:directories
      01 mkdir -p /home/hkobayash/sample/shared /home/hkobayash/sample/releases
    ✔ 01 hkobayash@127.0.0.1 0.017s
00:00 deploy:check:linked_dirs
      01 mkdir -p /home/hkobayash/sample/shared/log /home/hkobayash/sample/shared/tmp/pids /home/hkobayash/sample/shared/vendor/bundle
    ✔ 01 hkobayash@127.0.0.1 0.017s
00:00 bundle_rsync:bundler:install
      01 $HOME/.rbenv/bin/rbenv exec bundle --gemfile /home/hkobayash/capistrano-bundle_rsync/example/.local_repo/releases/20170206212205/Gemfile --deployment --quiet --path /home/hkobayash/capistrano-bundle…
      01 The --deployment flag requires a Gemfile.lock. Please make sure you have checked
      01 your Gemfile.lock into version control before deploying.
(Backtrace restricted to imported tasks)
cap aborted!
SSHKit::Command::Failed: bundle exit status: 4096
bundle stdout: The --deployment flag requires a Gemfile.lock. Please make sure you have checked
your Gemfile.lock into version control before deploying.
bundle stderr: Nothing written
```

`--gemfile` options passed no exist Gemfile.
I looks like `bundle_rsync_local_release_path` need to set as `repo_url`.