### PR TITLE
Support capistrano-3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,13 @@ require 'capistrano/deploy'
 
 # Includes tasks from other gems included in your Gemfile
 require 'capistrano/rbenv'
+
+# capistrano-3.3.3 - 3.6.1
 require 'capistrano/bundle_rsync'
+
+# capistrano-3.7+
+require 'capistrano/bundle_rsync/plugin'
+install_plugin Caipstrano::BundleRsync::Plugin
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }
@@ -158,7 +164,7 @@ set :branch, ENV['BRANCH'] || 'master'
 set :rbenv_type, :user
 set :linked_dirs, %w(log tmp/pids tmp/cache tmp/sockets vendor/bundle tmp/run)
 set :keep_releases, 5
-set :scm, :bundle_rsync # Need this
+set :scm, :bundle_rsync # Need this when run with capistrano-3.3.3 - 3.6.1
 set :bundle_rsync_max_parallels, ENV['PARA']
 set :bundle_rsync_rsync_bwlimit, ENV['BWLIMIT'] # like 20000
 set :bundle_rsync_config_files, ['~/config/database.yml']

--- a/example/Capfile
+++ b/example/Capfile
@@ -6,7 +6,13 @@ require 'capistrano/deploy'
 
 # Includes tasks from other gems included in your Gemfile
 require 'capistrano/rbenv'
-require 'capistrano/bundle_rsync'
+
+if Gem::Version.new(Capistrano::VERSION) < Gem::Version.new('3.7.0')
+  require 'capistrano/bundle_rsync'
+else
+  require 'capistrano/bundle_rsync/plugin'
+  install_plugin Capistrano::BundleRsync::Plugin
+end
 
 # Loads custom tasks from `lib/capistrano/tasks' if you have any defined.
 Dir.glob('lib/capistrano/tasks/*.rake').each { |r| import r }

--- a/example/config/deploy.rb
+++ b/example/config/deploy.rb
@@ -8,7 +8,10 @@ set :rbenv_type, :user
 set :rbenv_ruby, RUBY_VERSION # '2.1.5'
 set :deploy_to, "#{ENV['HOME']}/sample"
 
-set :scm, :bundle_rsync
+if Gem::Version.new(Capistrano::VERSION) < Gem::Version.new('3.7.0')
+  set :scm, :bundle_rsync
+end
+
 set :bundle_rsync_max_parallels, ENV['PARA']
 set :bundle_rsync_rsync_bwlimit, ENV['BWLIMIT'] # like 20000
 set :bundle_rsync_shared_dirs, File.expand_path('..', __dir__) # rsync example to shared/example

--- a/example/config/deploy/git.rb
+++ b/example/config/deploy/git.rb
@@ -1,3 +1,7 @@
+if Gem::Version.new(Capistrano::VERSION) < Gem::Version.new('3.7.0')
+  set :scm, :bundle_rsync
+end
+
 set :bundle_rsync_scm, 'git'
 set :repo_url, 'https://github.com/sonots/try_rails4'
 set :branch, 'master'

--- a/example/config/deploy/local_git.rb
+++ b/example/config/deploy/local_git.rb
@@ -1,3 +1,7 @@
+if Gem::Version.new(Capistrano::VERSION) < Gem::Version.new('3.7.0')
+  set :scm, :bundle_rsync
+end
+
 set :bundle_rsync_scm, 'local_git'
 set :repo_url, "#{ENV['PWD']}/try_rails4" # git clone git@github.com:sonots/try_rails4.git
 

--- a/example/config/deploy/skip_bundle.rb
+++ b/example/config/deploy/skip_bundle.rb
@@ -1,3 +1,7 @@
+if Gem::Version.new(Capistrano::VERSION) < Gem::Version.new('3.7.0')
+  set :scm, :bundle_rsync
+end
+
 set :bundle_rsync_scm, 'git'
 set :repo_url, 'https://github.com/sonots/try_rails4'
 set :branch, 'master'

--- a/lib/capistrano/bundle_rsync/plugin.rb
+++ b/lib/capistrano/bundle_rsync/plugin.rb
@@ -1,0 +1,14 @@
+require 'capistrano/bundle_rsync'
+require 'capistrano/scm/plugin'
+
+module Capistrano
+  module BundleRsync
+    class Plugin < Capistrano::SCM::Plugin
+      def register_hooks
+        after "deploy:new_release_path", "bundle_rsync:create_release"
+        before "deploy:check", "bundle_rsync:check"
+        before "deploy:set_current_revision", "bundle_rsync:set_current_revision"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch aims to support new capistrano plugin system with minimum changes.

BTW, If we can drop capistrano-3.6.x support on next release, I suggest change `Capistrano::BundleRsync` from module to subclass of `Capistrano::SCM::Plugin`, like [capistrano-puma](https://github.com/seuros/capistrano-puma).
