### PR TITLE
Modify bundle --without option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ bundle_rsync_config_files | `nil` | Additional files to rsync. Specified files a
 bundle_rsync_shared_dirs | `nil` | Additional directories to rsync. Specified directories are copied into `shared` directory.
 bundle_rsync_skip_bundle | false | (Secret option) Do not `bundle` and rsync bundle.
 bundle_rsync_bundle_install_standalone | `nil` | bundle install with --standalone option. Set one of `true`, `false`, an `Array` of groups, or a white space separated `String`.
+bundle_rsync_bundle_without | `[:development, :test]` | Configuration of bundle install with --without option.
 
 ## Task Orders
 

--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -5,7 +5,7 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
     Bundler.with_clean_env do
       with bundle_app_config: config.local_base_path do
-        opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without development test"
+        opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without #{config.bundle_without.join(' ')}"
         if standalone = config.bundle_install_standalone_option
           opts += " #{standalone}"
         end
@@ -27,7 +27,7 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
 ---
 BUNDLE_FROZEN: '1'
 BUNDLE_PATH: #{shared_path.join('bundle')}
-BUNDLE_WITHOUT: development:test
+BUNDLE_WITHOUT: #{config.bundle_without.join(':')}
 BUNDLE_DISABLE_SHARED_GEMS: '1'
 BUNDLE_BIN: #{release_path.join('bin')}
     EOS

--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -109,5 +109,9 @@ module Capistrano::BundleRsync
         nil
       end
     end
+
+    def self.bundle_without
+      fetch(:bundle_rsync_bundle_without) || [:development, :test]
+    end
   end
 end


### PR DESCRIPTION
I'd like to modify `bundle install --without` option.
I'm using a special group in Gemfile. I would not like to deploy the special group.
