### PR TITLE
Add `bundle --jobs` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ bundle_rsync_rsync_options | `-az --delete` | Configuration of rsync options.
 bundle_rsync_config_files | `nil` | Additional files to rsync. Specified files are copied into `config` directory.
 bundle_rsync_shared_dirs | `nil` | Additional directories to rsync. Specified directories are copied into `shared` directory.
 bundle_rsync_skip_bundle | false | (Secret option) Do not `bundle` and rsync bundle.
+bundle_rsync_bundle_install_jobs | `nil` | Configuration of bundle install with --jobs option.
 bundle_rsync_bundle_install_standalone | `nil` | bundle install with --standalone option. Set one of `true`, `false`, an `Array` of groups, or a white space separated `String`.
 bundle_rsync_bundle_without | `[:development, :test]` | Configuration of bundle install with --without option.
 

--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -6,6 +6,11 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
     Bundler.with_clean_env do
       with bundle_app_config: config.local_base_path do
         opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without #{config.bundle_without.join(' ')}"
+
+        if jobs = config.bundle_install_jobs
+          opts += " --jobs #{jobs}"
+        end
+
         if standalone = config.bundle_install_standalone_option
           opts += " #{standalone}"
         end

--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -93,6 +93,10 @@ module Capistrano::BundleRsync
       fetch(:bundle_rsync_skip_bundle)
     end
 
+    def self.bundle_install_jobs
+      fetch(:bundle_rsync_bundle_install_jobs)
+    end
+
     def self.bundle_install_standalone
       fetch(:bundle_rsync_bundle_install_standalone)
     end


### PR DESCRIPTION
The `--jobs` option makes it possible to run `bundle install` in parallel and it helps to speed up deployment.
This modification works fine on my local.

I would appreciate it if you could review this PR.
Thank you.