### PR TITLE
Allow capistrano-bundle_rsync to deploy different Ruby version correctly

### DIFF
--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -3,25 +3,27 @@ require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
-    Bundler.with_clean_env do
-      with bundle_app_config: config.local_base_path, rbenv_version: nil, rbenv_dir: nil do
-        bundle_commands = if test :rbenv, 'version'
-          %w[rbenv exec bundle]
-        else
-          %w[bundle]
-        end
+    within config.local_release_path do
+      Bundler.with_clean_env do
+        with bundle_app_config: config.local_base_path, rbenv_version: nil, rbenv_dir: nil do
+          bundle_commands = if test :rbenv, 'version'
+            %w[rbenv exec bundle]
+          else
+            %w[bundle]
+          end
 
-        opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without #{config.bundle_without.join(' ')}"
+          opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without #{config.bundle_without.join(' ')}"
 
-        if jobs = config.bundle_install_jobs
-          opts += " --jobs #{jobs}"
-        end
+          if jobs = config.bundle_install_jobs
+            opts += " --jobs #{jobs}"
+          end
 
-        if standalone = config.bundle_install_standalone_option
-          opts += " #{standalone}"
+          if standalone = config.bundle_install_standalone_option
+            opts += " #{standalone}"
+          end
+          execute *bundle_commands, opts
+          execute :rm, "#{config.local_base_path}/config"
         end
-        execute *bundle_commands, opts
-        execute :rm, "#{config.local_base_path}/config"
       end
     end
   end

--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -4,7 +4,7 @@ require 'capistrano/configuration/filter'
 class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
     Bundler.with_clean_env do
-      with bundle_app_config: config.local_base_path do
+      with bundle_app_config: config.local_base_path, rbenv_version: nil, rbenv_dir: nil do
         opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without #{config.bundle_without.join(' ')}"
 
         if jobs = config.bundle_install_jobs

--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -5,6 +5,12 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
     Bundler.with_clean_env do
       with bundle_app_config: config.local_base_path, rbenv_version: nil, rbenv_dir: nil do
+        bundle_commands = if test :rbenv, 'version'
+          %w[rbenv exec bundle]
+        else
+          %w[bundle]
+        end
+
         opts = "--gemfile #{config.local_release_path}/Gemfile --deployment --quiet --path #{config.local_bundle_path} --without #{config.bundle_without.join(' ')}"
 
         if jobs = config.bundle_install_jobs
@@ -14,7 +20,7 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
         if standalone = config.bundle_install_standalone_option
           opts += " #{standalone}"
         end
-        execute :bundle, opts
+        execute *bundle_commands, opts
         execute :rm, "#{config.local_base_path}/config"
       end
     end


### PR DESCRIPTION
## Background

When we are updating Ruby version of a Repository by `.ruby-version` of `rbenv`, we have found out that `bundle` command does not work as expected.

This occurs when there is a difference of Ruby version between deploying application version and deployed application version.

Let's assume we have a repository with Ruby 3.0.6, and we are deploying an old version of the same repository with Ruby 2.6.2. In this case, the current `bundle` is being run from Ruby 3.0.6, which is not an intended behavior.

## How we have fixed 

Fixing this issue is divided into 3 phase.

* Running `bundle`within `local_release_path`
  * This allows `rbenv` to decide Ruby version based on what is being deployed.
* Clearing environment variables of `RBENV_VERSION` and `RBENV_DIR`
  * In order to forget current ruby version, `RBENV_VERSION` is cleared.
  * In order to correctly search `.ruby-version`, `RBENV_DIR` is cleared.
  * https://github.com/rbenv/rbenv#environment-variables
* Prepend `rbenv exec` when it works
  * For backward compatibility, we only append `rbenv exec` when `rbenv version` is successful

## Other considerations to this patch

Since `rbenv` and `.ruby-version` is a de facto standard of Ruby ecosystem in 2023 and we are using them in production, this patch focuses only on `rbenv`.

Prepending `rbenv exec` to specific commands in Capistrano is usually achieved by `capistrano-rbenv`. However, this only affects `SSHKit.config.command_map`, which is effective only on remote command execution. Considering the local execution flow of `capistrano-bundle_rsync`, I thought it is rational to directly prepending `rbenv exec` here.
https://github.com/capistrano/rbenv#usage

## Test

We have successfully deployed Ruby 2.6.2 version from Ruby 3.0.6 by this patch.