### PR TITLE
Remove bundler version dependency for development

### DIFF
--- a/capistrano-bundle_rsync.gemspec
+++ b/capistrano-bundle_rsync.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'capistrano', '>= 3.3.3'
   spec.add_dependency 'parallel'
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3"
 end


### PR DESCRIPTION
As bundler 2 is stable now, I would like to use it when developing capistrano-bundle_rsync.

In my local environment, `bundle exec rspec` is successful with `Bundler version 2.4.13`