### PR TITLE
Remove unnecessary exit 1 for execute failure

### DIFF
--- a/lib/capistrano/bundle_rsync/git.rb
+++ b/lib/capistrano/bundle_rsync/git.rb
@@ -3,7 +3,7 @@ require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::Git < Capistrano::BundleRsync::SCM
   def check
-    exit 1 unless execute("git ls-remote #{repo_url} HEAD")
+    execute("git ls-remote #{repo_url} HEAD")
     execute("mkdir -p #{config.local_base_path}")
   end
 

--- a/lib/capistrano/bundle_rsync/local_git.rb
+++ b/lib/capistrano/bundle_rsync/local_git.rb
@@ -4,7 +4,7 @@ require 'capistrano/configuration/filter'
 class Capistrano::BundleRsync::LocalGit < Capistrano::BundleRsync::SCM
   def check
     raise ArgumentError.new('`repo_url` must be local path to use `local_git` scm') unless local_path?(repo_url)
-    exit 1 unless execute("git ls-remote #{repo_url} HEAD")
+    execute("git ls-remote #{repo_url} HEAD")
     execute("mkdir -p #{config.local_base_path}")
   end
 


### PR DESCRIPTION
`execute` in SSHKit raises exception unless `raise_on_non_zero_exit: false` option is explicitly specified.

Therefore, we can omit `exit 1` here.

c.f.
https://github.com/capistrano/capistrano/blob/31e142d56f8d894f28404fb225dcdbe7539bda18/lib/capistrano/scm/tasks/git.rake#L15-L22