### PR TITLE
Remove unnecessary method from Capistrano::BundleRsync::SCM

### DIFF
--- a/lib/capistrano/bundle_rsync/scm.rb
+++ b/lib/capistrano/bundle_rsync/scm.rb
@@ -7,19 +7,6 @@ require 'capistrano/configuration/filter'
 class Capistrano::BundleRsync::SCM < Capistrano::BundleRsync::Base
   # @abstract
   #
-  # Your implementation should check the existence of a cache repository on
-  # the deployment target
-  #
-  # @return [Boolean]
-  #
-  def test
-    raise NotImplementedError.new(
-      "Your SCM strategy module should provide a #test method"
-    )
-  end
-
-  # @abstract
-  #
   # Your implementation should check if the specified remote-repository is
   # available.
   #


### PR DESCRIPTION
While I am reading the code, I thought this method is no longer required for abstract class.

Both of `Capistrano::BundleRsync::Git` and `Capistrano::Bund` do not implement this method.
Probably, it seems like that this is something left when developing this gem.

Also, `test` is a little bit ambiguous considering the `test` of `SSHKit`.

The grep result for the remaining code is as follows:

```
% ag 'test' lib
lib/capistrano/bundle_rsync/config.rb
118:      fetch(:bundle_rsync_bundle_without) || [:development, :test]

lib/capistrano/bundle_rsync/bundler.rb
9:          bundle_commands = if test :rbenv, 'version'
```