### PR TITLE
More plugin support (`set_defaults`) for Capistrano 3.7+

### DIFF
--- a/lib/capistrano/bundle_rsync.rb
+++ b/lib/capistrano/bundle_rsync.rb
@@ -3,4 +3,7 @@ module Capistrano
   end
 end
 
+require 'capistrano/bundle_rsync/defaults'
+Capistrano::BundleRsync::Defaults.set_defaults
+
 load File.expand_path('../tasks/bundle_rsync.rake', __FILE__)

--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -1,23 +1,23 @@
 module Capistrano::BundleRsync
   class Config
     def self.local_base_path
-      @local_base_path ||= fetch(:bundle_rsync_local_base_path) || "#{Dir::pwd}/.local_repo"
+      @local_base_path ||= fetch(:bundle_rsync_local_base_path)
     end
 
     def self.local_mirror_path
-      @local_mirror_path ||= fetch(:bundle_rsync_local_mirror_path) || "#{local_base_path}/mirror"
+      @local_mirror_path ||= fetch(:bundle_rsync_local_mirror_path)
     end
 
     def self.local_releases_path
-      @local_releases_path ||= fetch(:bundle_rsync_local_releases_path) || "#{local_base_path}/releases"
+      @local_releases_path ||= fetch(:bundle_rsync_local_releases_path)
     end
 
     def self.local_release_path
-      @local_release_path ||= fetch(:bundle_rsync_local_release_path) || "#{local_releases_path}/#{Time.new.strftime('%Y%m%d%H%M%S')}"
+      @local_release_path ||= fetch(:bundle_rsync_local_release_path)
     end
 
     def self.local_bundle_path
-      @local_bundle_path ||= fetch(:bundle_rsync_local_bundle_path) || "#{local_base_path}/bundle"
+      @local_bundle_path ||= fetch(:bundle_rsync_local_bundle_path)
     end
 
     def self.config_files
@@ -60,7 +60,7 @@ module Capistrano::BundleRsync
     # NOTE: :password is not supported.
     def self.build_ssh_command(host)
       user_opt, key_opt, port_opt = "", "", ""
-      ssh_options = fetch(:bundle_rsync_ssh_options) || fetch(:ssh_options) || {}
+      ssh_options = fetch(:bundle_rsync_ssh_options)
       if user = host.user || ssh_options[:user]
         user_opt = " -l #{user}"
       end
@@ -75,7 +75,7 @@ module Capistrano::BundleRsync
     end
 
     def self.keep_releases
-      @keep_releases = fetch(:bundle_rsync_keep_releases) || fetch(:keep_releases)
+      @keep_releases = fetch(:bundle_rsync_keep_releases)
     end
 
     # Fetch the :bundle_rsync_max_parallels,
@@ -85,8 +85,7 @@ module Capistrano::BundleRsync
     end
 
     def self.rsync_options
-      bwlimit = fetch(:bundle_rsync_rsync_bwlimit) ? " --bwlimit #{fetch(:bundle_rsync_rsync_bwlimit)}" : ""
-      fetch(:bundle_rsync_rsync_options) || "-az --delete#{bwlimit}"
+      fetch(:bundle_rsync_rsync_options)
     end
 
     def self.skip_bundle
@@ -115,7 +114,7 @@ module Capistrano::BundleRsync
     end
 
     def self.bundle_without
-      fetch(:bundle_rsync_bundle_without) || [:development, :test]
+      fetch(:bundle_rsync_bundle_without)
     end
   end
 end

--- a/lib/capistrano/bundle_rsync/defaults.rb
+++ b/lib/capistrano/bundle_rsync/defaults.rb
@@ -19,6 +19,7 @@ module Capistrano
         set_if_empty :bundle_rsync_ssh_options, -> { fetch(:ssh_options, {}) }
         set_if_empty :bundle_rsync_keep_releases, -> { fetch(:keep_releases) }
 
+        set_if_empty :bundle_rsync_rsync_bwlimit, nil
         set_if_empty :bundle_rsync_rsync_options, -> {
           bwlimit = fetch(:bundle_rsync_rsync_bwlimit)
 
@@ -26,7 +27,12 @@ module Capistrano
           "-az --delete#{bwlimit_option}"
         }
 
+        set_if_empty :bundle_rsync_config_files, nil
+        set_if_empty :bundle_rsync_shared_dirs, nil
+
         set_if_empty :bundle_rsync_skip_bundle, false # NOTE: This is secret option
+        set_if_empty :bundle_rsync_bundle_install_jobs, nil
+        set_if_empty :bundle_rsync_bundle_install_standalone, nil
         set_if_empty :bundle_rsync_bundle_without, [:development, :test]
       end
     end

--- a/lib/capistrano/bundle_rsync/defaults.rb
+++ b/lib/capistrano/bundle_rsync/defaults.rb
@@ -19,6 +19,7 @@ module Capistrano
         set_if_empty :bundle_rsync_ssh_options, -> { fetch(:ssh_options, {}) }
         set_if_empty :bundle_rsync_keep_releases, -> { fetch(:keep_releases) }
 
+        set_if_empty :bundle_rsync_max_parallels, -> { release_roles(:all).size }
         set_if_empty :bundle_rsync_rsync_bwlimit, nil
         set_if_empty :bundle_rsync_rsync_options, -> {
           bwlimit = fetch(:bundle_rsync_rsync_bwlimit)

--- a/lib/capistrano/bundle_rsync/defaults.rb
+++ b/lib/capistrano/bundle_rsync/defaults.rb
@@ -1,0 +1,34 @@
+module Capistrano
+  module BundleRsync
+    module Defaults
+      def self.set_defaults
+        set_if_empty :bundle_rsync_scm, 'git'
+
+        set_if_empty :bundle_rsync_local_base_path, "#{Dir::pwd}/.local_repo"
+        set_if_empty :bundle_rsync_local_mirror_path, -> { "#{fetch(:bundle_rsync_local_base_path)}/mirror" }
+        set_if_empty :bundle_rsync_local_releases_path, -> { "#{fetch(:bundle_rsync_local_base_path)}/releases" }
+        set_if_empty :bundle_rsync_local_release_path, -> {
+          if fetch(:bundle_rsync_scm).to_s == 'local_git'
+            repo_url
+          else # git (default)
+            "#{fetch(:bundle_rsync_local_releases_path)}/#{Time.new.strftime('%Y%m%d%H%M%S')}"
+          end
+        }
+        set_if_empty :bundle_rsync_local_bundle_path, -> { "#{fetch(:bundle_rsync_local_base_path)}/bundle" }
+
+        set_if_empty :bundle_rsync_ssh_options, -> { fetch(:ssh_options, {}) }
+        set_if_empty :bundle_rsync_keep_releases, -> { fetch(:keep_releases) }
+
+        set_if_empty :bundle_rsync_rsync_options, -> {
+          bwlimit = fetch(:bundle_rsync_rsync_bwlimit)
+
+          bwlimit_option = bwlimit ? " --bwlimit #{bwlimit}" : ""
+          "-az --delete#{bwlimit_option}"
+        }
+
+        set_if_empty :bundle_rsync_skip_bundle, false # NOTE: This is secret option
+        set_if_empty :bundle_rsync_bundle_without, [:development, :test]
+      end
+    end
+  end
+end

--- a/lib/capistrano/bundle_rsync/plugin.rb
+++ b/lib/capistrano/bundle_rsync/plugin.rb
@@ -1,9 +1,14 @@
 require 'capistrano/bundle_rsync'
 require 'capistrano/scm/plugin'
+require 'capistrano/bundle_rsync/defaults'
 
 module Capistrano
   module BundleRsync
     class Plugin < Capistrano::SCM::Plugin
+      def set_defaults
+        Defaults.set_defaults
+      end
+
       def register_hooks
         after "deploy:new_release_path", "bundle_rsync:create_release"
         before "deploy:check", "bundle_rsync:check"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,20 @@
-require 'capistrano/all'
-
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'capistrano/bundle_rsync'
+
+# Emulate cap command
+# https://github.com/capistrano/capistrano/blob/31e142d56f8d894f28404fb225dcdbe7539bda18/bin/cap
+require "capistrano/all"
+
+# Emulate Capfile
+
+# Load DSL and Setup Up Stages
+require 'capistrano/setup'
+
+# Includes default deployment tasks
+require 'capistrano/deploy'
+
+if Gem::Version.new(Capistrano::VERSION) >= Gem::Version.new('3.7')
+  require 'capistrano/bundle_rsync/plugin'
+  install_plugin Capistrano::BundleRsync::Plugin
+else
+  require 'capistrano/bundle_rsync'
+end


### PR DESCRIPTION
Capistrano Plugin system requires SCM class to implement
`set_defaults` to set the default of settings by `set_if_empty` as follows.

https://github.com/capistrano/capistrano/blob/31e142d56f8d894f28404fb225dcdbe7539bda18/lib/capistrano/scm/git.rb#L8-L23

This patch makes `Capistrano::BundleRsync` to be compatible with the design.


In order to support the historical interface, both Plugin and `capistrano/bundle_rsync` loads the defaults via
`Capistrano::BundleRsync::Defaults.set_defaults`