### PR TITLE
Implement :git_turbo Strategy for Super-Fast Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ branch        | `master` | The Git branch to checkout.
 ssh_options   | `{}`  | Configuration of ssh :user and :keys.
 keep\_releases | 5 | The number of releases to keep.
 scm | nil | Must be `bundle_rsync` to use capistrano-bundle_rsync.
-bundle_rsync_scm | `git` | SCM Strategy inside `bundle_rsync`. `git` uses git. `local_git` also uses git, but it enables to rsync the git repository located on local path directly without git clone. `repo_url` must be the local directory path to use `local_git`.
+bundle_rsync_scm | `git` | SCM Strategy inside `bundle_rsync`. `git`, `local_git`, or `git_turbo` can be specified.
 bundle_rsync_local_base_path   | `$(pwd)/.local_repo` | The base directory to clone repository
 bundle_rsync_local_mirror_path | `#{base_path}/mirror"` | Path where to mirror your repository
 bundle_rsync_local_releases_path | `"#{base_path}/releases"` | The releases base directory to checkout your repository
@@ -68,6 +68,15 @@ bundle_rsync_skip_bundle | false | (Secret option) Do not `bundle` and rsync bun
 bundle_rsync_bundle_install_jobs | `nil` | Configuration of bundle install with --jobs option.
 bundle_rsync_bundle_install_standalone | `nil` | bundle install with --standalone option. Set one of `true`, `false`, an `Array` of groups, or a white space separated `String`.
 bundle_rsync_bundle_without | `[:development, :test]` | Configuration of bundle install with --without option.
+
+### BundleRsync SCM Strategies
+
+* git
+  * Original Strategy Using Git
+* local_git
+  * Directly Rsync Local (Non-Bare) Git Directory at `repo_url` Path to Remote Release Path
+* git_turbo
+  * Super-Fast Deployment Utilizing Git Worktree, Hardlink, and Rsync
 
 ## Task Orders
 

--- a/lib/capistrano/bundle_rsync/git_turbo.rb
+++ b/lib/capistrano/bundle_rsync/git_turbo.rb
@@ -6,6 +6,7 @@ class Capistrano::BundleRsync::GitTurbo < Capistrano::BundleRsync::SCM
   def check
     execute :git, 'ls-remote', repo_url, 'HEAD'
     execute :mkdir, '-p', config.local_base_path
+    execute :mkdir, '-p', config.local_releases_path
   end
 
   def clone

--- a/lib/capistrano/bundle_rsync/git_turbo.rb
+++ b/lib/capistrano/bundle_rsync/git_turbo.rb
@@ -1,0 +1,95 @@
+require 'pathname'
+require 'capistrano/bundle_rsync/scm'
+
+# Make Deployment Super-Fast by Utilizing Hardlink and Rsync
+class Capistrano::BundleRsync::GitTurbo < Capistrano::BundleRsync::SCM
+  def check
+    execute :git, 'ls-remote', repo_url, 'HEAD'
+    execute :mkdir, '-p', config.local_base_path
+  end
+
+  def clone
+    if test "[ -f #{config.local_mirror_path}/HEAD ]"
+      info t(:mirror_exists, at: config.local_mirror_path)
+    else
+      execute :git, :clone, '--mirror', repo_url, config.local_mirror_path
+    end
+  end
+
+  def update
+    within config.local_mirror_path do
+      execute :git, :remote, :update, '--prune'
+    end
+  end
+
+  def create_release
+    set_current_revision
+
+    worktree = local_worktree_path
+    if test "[ -f #{worktree.join('.git')} ]"
+      within worktree do
+        execute :git, 'checkout', '--detach', fetch(:current_revision)
+        execute :git, 'reset', '--hard'
+        execute :git, 'clean', '--force', '-x'
+      end
+    else
+      within config.local_mirror_path do
+        execute :git, 'worktree', 'add', '-f', '--detach', worktree, fetch(:current_revision)
+      end
+    end
+
+    source = fetch(:repo_tree) ? worktree.join(fetch(:repo_tree)) : worktree
+    within config.local_base_path do
+      execute :cp, '-al', source, config.local_release_path
+    end
+
+    within config.local_release_path do
+      execute :rm, '-f', '.git'
+    end
+  end
+
+  def clean_release
+    releases = capture(:ls, '-x', config.local_releases_path).split
+    if releases.count >= config.keep_releases
+      directories = (releases - releases.last(config.keep_releases))
+      if directories.any?
+        directories_str = directories.map do |release|
+          File.join(config.local_releases_path, release)
+        end.join(' ')
+        execute :rm, '-rf', directories_str
+      end
+    end
+  end
+
+  def rsync_release
+    hosts = release_roles(:all)
+    c = config
+    on hosts, in: :groups, limit: config.max_parallels(hosts), wait: 0 do |host|
+      execute :mkdir, '-p', releases_path
+
+      if source = capture(:ls, '-x', releases_path).split.last
+        execute :cp, '-al', releases_path.join(source), release_path
+      else
+        execute :mkdir, '-p', release_path
+      end
+
+      run_locally do
+        ssh = c.build_ssh_command(host)
+        execute :rsync, "#{c.rsync_options} --rsh='#{ssh}' #{c.local_release_path}/ #{host}:#{release_path}/"
+      end
+    end
+  end
+
+  def set_current_revision
+    within config.local_mirror_path do
+      set :current_revision, capture(:git, "rev-list --max-count=1 #{fetch(:branch)}")
+    end
+  end
+
+  private
+
+  def local_worktree_path
+    Pathname.new("#{fetch(:bundle_rsync_local_base_path)}/git_turbo_worktree")
+  end
+end
+

--- a/lib/capistrano/tasks/bundle_rsync.rake
+++ b/lib/capistrano/tasks/bundle_rsync.rake
@@ -15,10 +15,14 @@ namespace :bundle_rsync do
 
   def bundle_rsync_scm
     @bundle_rsync_scm ||=
-      if fetch(:bundle_rsync_scm).to_s == 'local_git'
+      case fetch(:bundle_rsync_scm).to_s
+      when 'local_git'
         require 'capistrano/bundle_rsync/local_git'
         set :bundle_rsync_local_release_path, repo_url
         Capistrano::BundleRsync::LocalGit.new(self)
+      when 'git_turbo'
+        require 'capistrano/bundle_rsync/git_turbo'
+        Capistrano::BundleRsync::GitTurbo.new(self)
       else
         require 'capistrano/bundle_rsync/git'
         Capistrano::BundleRsync::Git.new(self)


### PR DESCRIPTION
# Summary

I have implemented `:git_turbo` strategy for super-fast deployment.

This strategy utilizes Git Worktree, Hardlink, and Rsync.
Following are the procedures in this strategy.

1. Locally, checkout worktree to `.local_repo/git_turbo_worktree`.
2. Locally, copy hardlink files by `cp -al` from `.local_repo/git_turbo_worktree` to `local_release_path`.
3. Remotely, copy hardlink files by `cp -al` from last release to `release_path`.
4. Rsync files from `local_release_path` to remote `release_path`.

The hardlinked files minimize disk I/O usually required for making release directory.
Preserved content and file attributes minimize data transfer by `rsync`.

This strategy is most suitable for continuous deployment where the diff between consecutive releases is small.

# Performance

I have tested the time to deploy a Rails repository to a remote server.

* Approx. File Count: ~ 25,000
* Approx. Total File Size: ~ 2.7G

The result of deploying the same code is as follows:

* `bundle_rsync:create_release`
  * before: 6 sec
  * after: 8 sec
* `bundle_rsync:rsync_release`
  * before: 76 sec
  * after: 2 sec

Since the total cost of `bundle_rsync:rsync_release` is proportional to the number of servers,
30x faster `bundle_rsync:rsync_release` is effective for large-scale deployment.