### PR TITLE
Add `bundle_rsync_app_path` to specify where to run bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ bundle_rsync_rsync_bwlimit | nil | Configuration of rsync --bwlimit (KBPS) optio
 bundle_rsync_rsync_options | `-az --delete` | Configuration of rsync options.
 bundle_rsync_config_files | `nil` | Additional files to rsync. Specified files are copied into `config` directory.
 bundle_rsync_shared_dirs | `nil` | Additional directories to rsync. Specified directories are copied into `shared` directory.
+bundle_rsync_app_path | `.` | A relative app path from local `bundle_rsync_local_release_path` and from remote `release_path`. `bundle` commands are executed here, and directories like `.bundle/config` and `config` will be located in this directory.
 bundle_rsync_skip_bundle | false | (Secret option) Do not `bundle` and rsync bundle.
 bundle_rsync_bundle_install_jobs | `nil` | Configuration of bundle install with --jobs option.
 bundle_rsync_bundle_install_standalone | `nil` | bundle install with --standalone option. Set one of `true`, `false`, an `Array` of groups, or a white space separated `String`.

--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -3,7 +3,7 @@ require 'capistrano/configuration/filter'
 
 class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
   def install
-    within config.local_release_path do
+    within config.local_release_app_path do
       Bundler.public_send(Bundler.respond_to?(:with_unbundled_env) ? :with_unbundled_env : :with_clean_env) do
         with bundle_app_config: config.local_base_path, rbenv_version: nil, rbenv_dir: nil do
           bundle_commands = if test :rbenv, 'version'
@@ -34,8 +34,9 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
 
   def rsync
     hosts = release_roles(:all)
+    release_app_path = config.release_app_path
     on hosts, in: :groups, limit: config.max_parallels(hosts) do
-      within release_path do
+      within release_app_path do
         execute :mkdir, '-p', '.bundle'
       end
     end
@@ -46,7 +47,7 @@ BUNDLE_FROZEN: '1'
 BUNDLE_PATH: #{shared_path.join('bundle')}
 BUNDLE_WITHOUT: #{config.bundle_without.join(':')}
 BUNDLE_DISABLE_SHARED_GEMS: '1'
-BUNDLE_BIN: #{release_path.join('bin')}
+BUNDLE_BIN: #{release_app_path.join('bin')}
     EOS
     # BUNDLE_BIN requires rbenv-binstubs plugin to make it effectively work
     bundle_config_path = "#{config.local_base_path}/bundle_config"
@@ -57,7 +58,7 @@ BUNDLE_BIN: #{release_path.join('bin')}
     Parallel.each(hosts, in_threads: config.max_parallels(hosts)) do |host|
       ssh = config.build_ssh_command(host)
       execute :rsync, "#{rsync_options} --rsh='#{ssh}' #{config.local_bundle_path}/ #{host}:#{shared_path}/bundle/"
-      execute :rsync, "#{rsync_options} --rsh='#{ssh}' #{bundle_config_path} #{host}:#{release_path}/.bundle/config"
+      execute :rsync, "#{rsync_options} --rsh='#{ssh}' #{bundle_config_path} #{host}:#{release_app_path}/.bundle/config"
     end
   end
 end

--- a/lib/capistrano/bundle_rsync/config.rb
+++ b/lib/capistrano/bundle_rsync/config.rb
@@ -16,8 +16,16 @@ module Capistrano::BundleRsync
       @local_release_path ||= fetch(:bundle_rsync_local_release_path)
     end
 
+    def self.local_release_app_path
+      @local_release_app_path ||= Pathname.new(local_release_path).join(fetch(:bundle_rsync_app_path))
+    end
+
     def self.local_bundle_path
       @local_bundle_path ||= fetch(:bundle_rsync_local_bundle_path)
+    end
+
+    def self.release_app_path
+      @release_app_path ||= release_path.join(fetch(:bundle_rsync_app_path))
     end
 
     def self.config_files

--- a/lib/capistrano/bundle_rsync/defaults.rb
+++ b/lib/capistrano/bundle_rsync/defaults.rb
@@ -30,6 +30,7 @@ module Capistrano
 
         set_if_empty :bundle_rsync_config_files, nil
         set_if_empty :bundle_rsync_shared_dirs, nil
+        set_if_empty :bundle_rsync_app_path, '.'
 
         set_if_empty :bundle_rsync_skip_bundle, false # NOTE: This is secret option
         set_if_empty :bundle_rsync_bundle_install_jobs, nil

--- a/lib/capistrano/bundle_rsync/scm.rb
+++ b/lib/capistrano/bundle_rsync/scm.rb
@@ -94,7 +94,7 @@ class Capistrano::BundleRsync::SCM < Capistrano::BundleRsync::Base
     if config_files = config.config_files
       Parallel.each(hosts, in_threads: config.max_parallels(hosts)) do |host|
         ssh = config.build_ssh_command(host)
-        execute :rsync, rsync_options, "--rsh='#{ssh}'", *config_files.map(&:to_s), "#{host}:#{release_path}/config/"
+        execute :rsync, rsync_options, "--rsh='#{ssh}'", *config_files.map(&:to_s), "#{host}:#{config.release_app_path}/config/"
       end
     end
 


### PR DESCRIPTION
Capistrano::BundleRsync assumes that the top directory of the repository is the app directory.
Therefore, this runs `bundle` commands and locates `config` directory and `.bundle/config` files there.

This is simple but cannot fully support repositories where app directory locates in the subdirectory from the top directory.

Unlike `:git_tree`, this feature even support apps which have dependency in other sub directories.

The main use cases of feature is to support multi-apps repository with shared directory.


e.g.

```
* api-server-1 (depends on shared)
* api-server-2 (depends on shared)
* html-server (depends on shared)
* shared
```