### PR TITLE
Add New Ruby versions with head for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ jobs:
           - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
+          - '3.4'
+          - 'head'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
By this way, we can test the gem with newer and latest versions of Ruby.