### PR TITLE
compatible with Bundler 4

### DIFF
--- a/lib/capistrano/bundle_rsync/bundler.rb
+++ b/lib/capistrano/bundle_rsync/bundler.rb
@@ -12,9 +12,9 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
             %w[bundle]
           end
 
-          execute *bundle_commands, 'config', '--local', 'deployment', 'true'
-          execute *bundle_commands, 'config', '--local', 'path', config.local_bundle_path
-          execute *bundle_commands, 'config', '--local', 'without', *config.bundle_without
+          execute *bundle_commands, 'config', 'set', '--local', 'deployment', 'true'
+          execute *bundle_commands, 'config', 'set', '--local', 'path', config.local_bundle_path
+          execute *bundle_commands, 'config', 'set', '--local', 'without', *config.bundle_without
 
           opts = ['--quiet']
           if jobs = config.bundle_install_jobs
@@ -25,7 +25,7 @@ class Capistrano::BundleRsync::Bundler < Capistrano::BundleRsync::Base
             opts.push(standalone)
           end
 
-          execute *bundle_commands, *opts
+          execute *bundle_commands, 'install', *opts
           execute :rm, "#{config.local_base_path}/config"
         end
       end


### PR DESCRIPTION
## Summary

Migrate deprecated Bundler APIs and commands to support Bundler 4.

## Changes

- `bundle` -> `bundle install`
  - Running just bundle to mean bundle install is not recommended anymore
see: https://blog.rubygems.org/2025/12/03/upgrade-to-rubygems-bundler-4.html

- Fix bundle config deprecation warning